### PR TITLE
Add TopologyTree Data Struct + RequestRealTimeGraph functionality

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.5.5

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.5

--- a/scala_core/project/metals.sbt
+++ b/scala_core/project/metals.sbt
@@ -2,5 +2,5 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.11")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.12")
 

--- a/scala_core/project/project/metals.sbt
+++ b/scala_core/project/project/metals.sbt
@@ -2,5 +2,5 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.11")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.12")
 

--- a/scala_core/project/project/project/metals.sbt
+++ b/scala_core/project/project/project/metals.sbt
@@ -2,5 +2,5 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.11")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.12")
 

--- a/scala_core/src/main/scala/org/nimbleedge/recoedge/Aggregator.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/recoedge/Aggregator.scala
@@ -1,6 +1,8 @@
 package org.nimbleedge.recoedge
 
 import models._
+import scala.concurrent.duration._
+import scala.collection.mutable.{Map => MutableMap}
 
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
@@ -9,7 +11,6 @@ import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.Signal
 import akka.actor.typed.PostStop
-import scala.collection.mutable.{Map => MutableMap}
 
 object Aggregator {
     def apply(aggId: AggregatorIdentifier): Behavior[Command] =
@@ -30,7 +31,7 @@ object Aggregator {
 
 class Aggregator(context: ActorContext[Aggregator.Command], aggId: AggregatorIdentifier) extends AbstractBehavior[Aggregator.Command](context) {
     import Aggregator._
-    import FLSystemManager.{ RequestTrainer, TrainerRegistered, RequestAggregator, AggregatorRegistered, RequestTopology }
+    import FLSystemManager.{ RequestTrainer, TrainerRegistered, RequestAggregator, AggregatorRegistered, RequestRealTimeGraph }
 
     // TODO
     // Add state and persistent information
@@ -117,15 +118,23 @@ class Aggregator(context: ActorContext[Aggregator.Command], aggId: AggregatorIde
                 }
                 this    
             
-            case trackMsg @ RequestTopology(requestId, entity, replyTo) =>
+            case trackMsg @ RequestRealTimeGraph(requestId, entity, replyTo) =>
                 entity match {
                     case Left(x) => 
-                        context.log.info("Cannot get topology for an orchestrator entity: got {}", x.toString())
+                        context.log.info("Cannot get realTimeGraph for an orchestrator entity: got {}", x.toString())
 
                     case Right(x) => 
                         if (aggId == x) {
-                            // TODO
-                            // return/build the current node's topology
+                            // return/build the current node's realTimeGraph
+                            context.log.info("Creating new realTimeGraph query actor for {}", entity)
+                            context.spawnAnonymous(RealTimeGraphQuery(
+                              creator = entity,
+                              aggIdToRefMap = aggregatorIdsToRef.toMap,
+                              traIds = Some(trainerIdsToRef.keys.toList),
+                              requestId = requestId,
+                              requester = replyTo,
+                              timeout = 30.seconds
+                            ))
                         } else {
                             val aggList = x.getAggregators()
                             if (aggList.find(y => {aggId == y}) == None) {

--- a/scala_core/src/main/scala/org/nimbleedge/recoedge/Aggregator.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/recoedge/Aggregator.scala
@@ -17,7 +17,7 @@ object Aggregator {
     
     trait Command
 
-    // In cae of any Trainer / Aggregator (Chile) Termination
+    // In case of any Trainer / Aggregator (Child) Termination
     private final case class AggregatorTerminated(actor: ActorRef[Aggregator.Command], aggId: AggregatorIdentifier)
         extends Aggregator.Command
     

--- a/scala_core/src/main/scala/org/nimbleedge/recoedge/FLSystemManager.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/recoedge/FLSystemManager.scala
@@ -41,13 +41,13 @@ object FLSystemManager {
     private final case class OrchestratorTerminated(actor: ActorRef[Orchestrator.Command], orcId: OrchestratorIdentifier)
         extends FLSystemManager.Command
 
-    // Requesting Topology
-    final case class RequestTopology(requestId: Long, entity: Either[OrchestratorIdentifier, AggregatorIdentifier], replyTo: ActorRef[Topology])
+    // Requesting RealTimeGraph
+    final case class RequestRealTimeGraph(requestId: Long, entity: Either[OrchestratorIdentifier, AggregatorIdentifier], replyTo: ActorRef[RespondRealTimeGraph])
         extends FLSystemManager.Command
         with Orchestrator.Command
         with Aggregator.Command
     
-    final case class Topology(requestId: Long, topology: TopologyTree)
+    final case class RespondRealTimeGraph(requestId: Long, realTimeGraph: TopologyTree)
 
     // Start cycle
     // TODO
@@ -62,7 +62,7 @@ class FLSystemManager(context: ActorContext[FLSystemManager.Command]) extends Ab
     import FLSystemManager._
 
     // TODO
-    // Topology
+    // Topology ??
     // State Information
     var orcIdToRef : MutableMap[OrchestratorIdentifier, ActorRef[Orchestrator.Command]] = MutableMap.empty
 
@@ -102,7 +102,7 @@ class FLSystemManager(context: ActorContext[FLSystemManager.Command]) extends Ab
                 orchestratorRef ! trackMsg
                 this
             
-            case trackMsg @ RequestTopology(requestId, entity, replyTo) =>
+            case trackMsg @ RequestRealTimeGraph(requestId, entity, replyTo) =>
                 val orcId = entity match {
                     case Left(x) => x
                     case Right(x) => x.getOrchestrator()
@@ -112,7 +112,7 @@ class FLSystemManager(context: ActorContext[FLSystemManager.Command]) extends Ab
                     case Some(actorRef) =>
                         actorRef ! trackMsg
                     case None =>
-                        context.log.info("Orchestrator with id {} does not exist, can't request topology", orcId.name())
+                        context.log.info("Orchestrator with id {} does not exist, can't request realTimeGraph", orcId.name())
                 }
                 this
             

--- a/scala_core/src/main/scala/org/nimbleedge/recoedge/FLSystemManager.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/recoedge/FLSystemManager.scala
@@ -47,8 +47,7 @@ object FLSystemManager {
         with Orchestrator.Command
         with Aggregator.Command
     
-    // TODO
-    final case class Topology(requestId: Long)
+    final case class Topology(requestId: Long, topology: TopologyTree)
 
     // Start cycle
     // TODO

--- a/scala_core/src/main/scala/org/nimbleedge/recoedge/RealTimeGraphQuery.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/recoedge/RealTimeGraphQuery.scala
@@ -1,0 +1,143 @@
+package org.nimbleedge.recoedge
+
+import org.nimbleedge.recoedge.models._
+import scala.concurrent.duration.FiniteDuration
+import akka.actor.typed.Behavior
+import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.TimerScheduler
+import akka.actor.typed.scaladsl.AbstractBehavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.PostStop
+import akka.actor.typed.Signal
+
+import FLSystemManager.{ RespondRealTimeGraph }
+
+// Map of Aggregator Identifiers is compulsory
+// List of Trainer Identifiers is optional
+
+object RealTimeGraphQuery {
+	def apply(
+		creator: Either[OrchestratorIdentifier, AggregatorIdentifier],
+		aggIdToRefMap: Map[AggregatorIdentifier, ActorRef[Aggregator.Command]],
+		traIds: Option[List[TrainerIdentifier]],
+		requestId: Long,
+		requester: ActorRef[RespondRealTimeGraph],
+		timeout: FiniteDuration
+	) : Behavior[Command] = {
+		Behaviors.setup { context =>
+			Behaviors.withTimers { timers =>
+				new RealTimeGraphQuery(creator, aggIdToRefMap, traIds, requestId, requester, timeout, context, timers)
+			}
+		}
+	}
+
+	trait Command
+	private case object CollectionTimeout extends Command
+
+	final case class WrappedRespondRealTimeGraph(response: RespondRealTimeGraph) extends Command
+
+	private final case class AggregatorTerminated(aggId: AggregatorIdentifier) extends Command
+}
+
+class RealTimeGraphQuery(
+	creator: Either[OrchestratorIdentifier, AggregatorIdentifier],
+	aggIdToRefMap: Map[AggregatorIdentifier, ActorRef[Aggregator.Command]],
+	traIds: Option[List[TrainerIdentifier]],
+	requestId: Long,
+	requester: ActorRef[RespondRealTimeGraph],
+	timeout: FiniteDuration,
+	context: ActorContext[RealTimeGraphQuery.Command],
+	timers: TimerScheduler[RealTimeGraphQuery.Command]
+) extends AbstractBehavior[RealTimeGraphQuery.Command](context) {
+	import RealTimeGraphQuery._
+
+	timers.startSingleTimer(CollectionTimeout, CollectionTimeout, timeout)
+
+	private val respondRealTimeGraphAdapter = context.messageAdapter(WrappedRespondRealTimeGraph.apply)
+
+	private var repliesSoFar = Map.empty[AggregatorIdentifier, TopologyTree]
+	private var stillWaiting = aggIdToRefMap.keySet
+
+  	context.log.info("RealTimeGraphQuery Actor for {} started", creator)
+
+	if (aggIdToRefMap.isEmpty) {
+		respondWhenAllCollected()
+	} else {
+		aggIdToRefMap.foreach {
+			case (aggId, aggRef) =>
+				context.watchWith(aggRef, AggregatorTerminated(aggId))
+				aggRef ! FLSystemManager.RequestRealTimeGraph(0, Right(aggId), respondRealTimeGraphAdapter)
+		}
+	}
+
+	override def onMessage(msg: Command): Behavior[Command] =
+		msg match {
+			case WrappedRespondRealTimeGraph(response) => onRespondRealTimeGraph(response)
+			case AggregatorTerminated(aggId) 	  => onAggregatorTerminated(aggId)
+			case CollectionTimeout 				  => onCollectionTimeout()
+		}
+
+	private def onRespondRealTimeGraph(response: RespondRealTimeGraph) : Behavior[Command] = {
+		val realTimeGraph = response.realTimeGraph
+		val aggId : AggregatorIdentifier = response.realTimeGraph match {
+
+			// The Topology Tree will always be a node since
+			// We are requesting realTimeGraph only from Orchestrator/Aggregators.
+
+			case Leaf(x) => throw new NotImplementedError
+			case Node(value, children) => value match {
+
+				// OrchestratorIdentifier is never used!
+				// The entity received here should not be Orchestrator Identifier
+				// Since these are messages which will be received by self.
+
+				case Left(x) => throw new NotImplementedError
+				case Right(x) => x
+			}
+		}
+
+		repliesSoFar += (aggId -> realTimeGraph)
+		stillWaiting -= aggId
+		respondWhenAllCollected()
+	}
+
+	private def onAggregatorTerminated(aggId: AggregatorIdentifier): Behavior[Command] = {
+		if (stillWaiting(aggId)) {
+			// Send the empty List of children when Aggregator terminated.
+			repliesSoFar += (aggId -> Node(Right(aggId), Set.empty))
+			stillWaiting -= aggId
+		}
+		respondWhenAllCollected()
+	}
+
+	private def onCollectionTimeout(): Behavior[Command] = {
+		// Send the empty List of children for Aggregators who didn't respond
+		repliesSoFar ++= stillWaiting.map(aggId => aggId -> Node(Right(aggId), Set.empty))
+		stillWaiting = Set.empty
+		respondWhenAllCollected()
+	}
+
+	private def respondWhenAllCollected(): Behavior[Command] = {
+		if (stillWaiting.isEmpty) {
+			// Construct a tree and return to requester
+			val children : Set[TopologyTree] = {
+				val trainers: Set[TopologyTree] = traIds match {
+					case Some(list) => list.map(traId => Leaf(traId)).toSet
+					case None => Set.empty
+				}
+				repliesSoFar.values.toSet ++ trainers
+			}
+			requester ! RespondRealTimeGraph(requestId, Node(creator, children))	
+			Behaviors.stopped
+		} else {
+			this
+		}
+	}
+
+	override def onSignal: PartialFunction[Signal, Behavior[Command]] = {
+		case PostStop =>
+			context.log.info("RealTimeGraphQuery Actor for {} stopped", creator)
+			this
+	}
+}

--- a/scala_core/src/main/scala/org/nimbleedge/recoedge/models/Identifier.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/recoedge/models/Identifier.scala
@@ -4,7 +4,7 @@ import java.security.{MessageDigest => MD}
 import java.nio.ByteBuffer
 import scala.collection.mutable.ListBuffer
 
-abstract class Identifier {
+sealed abstract class Identifier {
     def name() : String
     def computeDigest() : Array[Byte]
     val digest : Array[Byte] = computeDigest()

--- a/scala_core/src/main/scala/org/nimbleedge/recoedge/models/TopologyTree.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/recoedge/models/TopologyTree.scala
@@ -8,13 +8,16 @@ sealed abstract class TopologyTree {
 	val digest : Array[Byte] = computeDigest()
 	override val hashCode : Int = ByteBuffer.wrap(digest.slice(0,4)).getInt
 
-	def hash(baseName: String, args: List[TopologyTree]): Array[Byte] = {
+	def hash(baseName: String, args: Set[TopologyTree]): Array[Byte] = {
 		val md = MD.getInstance("SHA-256")
 		md.reset()
 		md.update(baseName.getBytes("UTF-8"))
-		args.foreach(
-			arg => md.update(arg.digest)
-		)
+
+		// Two Same Sets will always have the same hashcode
+		// Instead of computing hashcode separately for the sets,
+		// We use their internal one.
+		md.update(ByteBuffer.allocate(4).putInt(args.hashCode()).array())
+
 		md.digest()
 	}
 
@@ -26,7 +29,6 @@ sealed abstract class TopologyTree {
 	}
 }
 
-
 // Creating Leaf and Node separately for keeping the distinction between Trainers
 // and Orchestrators + Aggregators
 
@@ -34,12 +36,12 @@ sealed abstract class TopologyTree {
 case class Leaf(value: TrainerIdentifier) extends TopologyTree {
 	override def toString(): String = value.name()
 
-	override def computeDigest(): Array[Byte] = hash("_Leaf" + value.name(), List.empty)
+	override def computeDigest(): Array[Byte] = hash("_Leaf" + value.name(), Set.empty)
 }
 
 // Node can be only OrchestratorIdentifier or AggregatorIdentifier
 // It should have more that one children
-case class Node(value: Either[OrchestratorIdentifier, AggregatorIdentifier], children: List[TopologyTree]) extends TopologyTree {
+case class Node(value: Either[OrchestratorIdentifier, AggregatorIdentifier], children: Set[TopologyTree]) extends TopologyTree {
 	override def toString(): String = {
 		val node_value : String = value match {
 			case Left(x) => x.name()

--- a/scala_core/src/main/scala/org/nimbleedge/recoedge/models/TopologyTree.scala
+++ b/scala_core/src/main/scala/org/nimbleedge/recoedge/models/TopologyTree.scala
@@ -1,0 +1,58 @@
+package org.nimbleedge.recoedge.models
+
+import java.security.{MessageDigest => MD}
+import java.nio.ByteBuffer
+
+sealed abstract class TopologyTree {
+	def computeDigest() : Array[Byte]
+	val digest : Array[Byte] = computeDigest()
+	override val hashCode : Int = ByteBuffer.wrap(digest.slice(0,4)).getInt
+
+	def hash(baseName: String, args: List[TopologyTree]): Array[Byte] = {
+		val md = MD.getInstance("SHA-256")
+		md.reset()
+		md.update(baseName.getBytes("UTF-8"))
+		args.foreach(
+			arg => md.update(arg.digest)
+		)
+		md.digest()
+	}
+
+	override def equals(identifier_val: Any): Boolean = {
+		identifier_val match {
+			case i : TopologyTree => hashCode == identifier_val.hashCode && MD.isEqual(digest, i.digest)
+			case _ => false
+		}
+	}
+}
+
+
+// Creating Leaf and Node separately for keeping the distinction between Trainers
+// and Orchestrators + Aggregators
+
+// Leaf will always be a TrainerIdentifier
+case class Leaf(value: TrainerIdentifier) extends TopologyTree {
+	override def toString(): String = value.name()
+
+	override def computeDigest(): Array[Byte] = hash("_Leaf" + value.name(), List.empty)
+}
+
+// Node can be only OrchestratorIdentifier or AggregatorIdentifier
+// It should have more that one children
+case class Node(value: Either[OrchestratorIdentifier, AggregatorIdentifier], children: List[TopologyTree]) extends TopologyTree {
+	override def toString(): String = {
+		val node_value : String = value match {
+			case Left(x) => x.name()
+			case Right(x) => x.name()
+		}
+		node_value + children.mkString("(", ", ", ")")
+	}
+
+	override def computeDigest(): Array[Byte] = {
+		val node_value : String = value match {
+			case Left(x) => "_Node_Orc" + x.name()
+			case Right(x) => "_Node_Agg" + x.name()
+		}
+		hash(node_value, children)
+	}
+}

--- a/scala_core/src/test/scala/org/nimbleedge/recoedge/FLSystemManagerSpec.scala
+++ b/scala_core/src/test/scala/org/nimbleedge/recoedge/FLSystemManagerSpec.scala
@@ -1,5 +1,7 @@
 package org.nimbleedge.recoedge
 
+import scala.concurrent.duration._
+
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -68,6 +70,20 @@ class FLSystemManagerSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike
 			val aggActor2 = registered4.actor
 
 			aggActor1 should !==(aggActor2)
+
+			// Test RealTimeGraph
+			val realTimeGraphProbe = createTestProbe[RespondRealTimeGraph]()
+
+			managerActor ! RequestRealTimeGraph(104, Left(o1), realTimeGraphProbe.ref)
+			val registered5 = realTimeGraphProbe.receiveMessage(35.seconds)
+			val expectedTree = Node(
+				Left(o1), Set(
+					Node(Right(a1), Set.empty),
+					Node(Right(a2), Set(
+						Leaf(t3),
+						Node(Right(a3), Set(
+							Leaf(t5)))))))
+			registered5.realTimeGraph should ===(expectedTree)
 
 			// TODO
 			// add more tests here


### PR DESCRIPTION
This allows us to create the TopologyTree using the Identifiers data structures.

RequestRealTimeGraph query creates a parallel Actor (analogous to thread) for completing the query regarding fetching and constructing the RealTimeGraph.

RealTimeGraphQuery Actor can create multiple actors recursively for doing more requests. This finally returns the result to the requesting actor.